### PR TITLE
Chat 33 enable users to customise the chatbots initial entry message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 .env
 
 .env.local
+
+# Local md file
+DEVELOPER_ONBOARDING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased]
 
+- Supabase welcome_message Chatbot table field now defaults to null. **[CHAT-33]**
+- Removed chatbot on create default from ChatbotBuilder.tsx. **[CHAT-33]**
+- Fixed odd scrolling in PublicChat.tsx, added a logic for chatbot to default to use welcome_message property or default Hello! I'm ${chatbot.name}. ${chatbot.description} How can I help you today? **[CHAT-33]**
+
 ### 1.1.0 (2025-08-21)
 
 ### Fixed
@@ -33,6 +37,7 @@ All notable changes to this project will be documented in this file. See [standa
 - Shared types: `src/types/knowledge.ts` with `ProcessedFile`, `KnowledgeItem`, `UploadStatus`, etc. **[CHAT-35]**
 
 ### Changed
+
 - **Do not mark items as completed on submit**: items remain `processing` until DB marks `processed=true` or `status='error'`.
 - **FileUpload**:
   - Strong TS types (no `any`), safe ID generation, per-selection limits, size/type validation, dedupe by `name+size`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4875,6 +4875,7 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=8"
       }

--- a/src/components/ChatbotBuilder.tsx
+++ b/src/components/ChatbotBuilder.tsx
@@ -34,7 +34,7 @@ export const ChatbotBuilder = () => {
         description: formData.description,
         user_id: user.id,
         bot_role_template_id: formData.bot_role_template_id,
-        welcome_message: selectedTemplate?.welcome_message ?? "Hello!",
+        // welcome_message: selectedTemplate?.welcome_message ?? "Hello!",
         placeholder: selectedTemplate?.placeholder ?? "Ask me anything...",
         bot_avatar: selectedTemplate?.bot_avatar ?? null,
         status: "processing",

--- a/src/components/PublicChat.tsx
+++ b/src/components/PublicChat.tsx
@@ -22,6 +22,9 @@ interface Message {
 }
 
 export const PublicChat = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   const { chatbotId } = useParams<{ chatbotId: string }>();
   const { data: chatbot, isLoading: chatbotLoading } = useChatbot(
     chatbotId || ""
@@ -33,20 +36,22 @@ export const PublicChat = () => {
   const [isMinimized, setIsMinimized] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
+  // const scrollToBottom = () => {
+  //   messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  // };
 
-  useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
+  // useEffect(() => {
+  //   scrollToBottom();
+  // }, [messages]);
 
   useEffect(() => {
     if (chatbot) {
       setMessages([
         {
           id: "1",
-          text: `Hello! I'm ${chatbot.name}. ${chatbot.description} How can I help you today?`,
+          text: chatbot.welcome_message
+          ? chatbot.welcome_message
+          : `Hello! I'm ${chatbot.name}. ${chatbot.description} How can I help you today?`,
           sender: "bot",
           timestamp: new Date(),
         },


### PR DESCRIPTION
## [Unreleased]

- Supabase welcome_message Chatbot table field now defaults to null. **[CHAT-33]**
- Removed chatbot on create default from ChatbotBuilder.tsx. **[CHAT-33]**
- Fixed odd scrolling in PublicChat.tsx, added a logic for chatbot to default to use welcome_message property or default Hello! I'm ${chatbot.name}. ${chatbot.description} How can I help you today? **[CHAT-33]**